### PR TITLE
Target .NET 6

### DIFF
--- a/Ramstack.Globbing.Tests/Ramstack.Globbing.Tests.csproj
+++ b/Ramstack.Globbing.Tests/Ramstack.Globbing.Tests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Ramstack.Globbing</RootNamespace>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Using Include="NUnit.Framework" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="4.1.0"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Ramstack.Globbing\Ramstack.Globbing.csproj" />
   </ItemGroup>

--- a/Ramstack.Globbing/Ramstack.Globbing.csproj
+++ b/Ramstack.Globbing/Ramstack.Globbing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Description>Fast and zero-allocation .NET globbing library for matching file paths using glob patterns.</Description>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
- Change target framework from multi-targeting (`net6.0`, `net8.0`) to single target `net6.0`
- Replace conditional compilation for `.NET 8` with a universal approach
- Implement efficient `**` pattern check for all .NET targets