### PR TITLE
Refactor parameter order in IsMatch method for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ dotnet add package Ramstack.Globbing
 ## Usage
 
 ```csharp
-bool result = Matcher.IsMatch("wiki/**/*.md", "wiki/section-1/start.md");
+bool result = Matcher.IsMatch("wiki/section-1/start.md", "wiki/**/*.md");
 ```
 The `IsMatch` method attempts to match the specified path against the provided wildcard pattern.
 
@@ -27,7 +27,7 @@ By default, the system's default path separators are used. You can override this
 
 Example with a specific flag:
 ```csharp
-bool result = Matcher.IsMatch(@"wiki\**\*.md", "wiki/section-1/start.md", MatchFlags.Windows);
+bool result = Matcher.IsMatch("wiki/section-1/start.md", @"wiki\**\*.md", MatchFlags.Windows);
 ```
 
 ## Patterns
@@ -98,6 +98,23 @@ matching against the text `aaaaaaaaaaaaaaa...aaaa...aaa`.
 Similarly, for the `a/**/a/**/a/**/.../a/**/a/**/a/**/b` pattern matching against `a/a/a/a/.../a/.../a`.
 
 ## Changelog
+
+### 2.0.0
+**BREAKING CHANGE**
+
+To improve code readability and adherence to .NET conventions, the order of parameters in the `IsMatch` method has been changed.
+The `path` parameter is now first, followed by the `pattern` parameter.
+
+**New signature**
+```csharp
+public static bool IsMatch(string path, string pattern, MatchFlags flags = MatchFlags.Auto)
+```
+**Reasons for the change:**
+* Consistency with .NET methods: The primary object of an action is typically the first parameter.
+  Here, `path` is the primary object, and `pattern` is the secondary.
+* Alignment with common APIs: This order matches other .NET methods like `Regex.IsMatch(string input, string pattern)`.
+* Flexibility for future expansions: Having the most commonly varied parameter (pattern) second makes it easier to create intuitive method overloads in the future.
+* **Early stage of development:** Since the library is newly released, we've made this change to ensure consistency from the start.
 
 ### 1.1.0
 - Change target framework from multi-targeting (`net6.0`;`net8.0`) to single target `net6.0`

--- a/Ramstack.Globbing.Tests/MatcherTests.cs
+++ b/Ramstack.Globbing.Tests/MatcherTests.cs
@@ -294,7 +294,7 @@ public class MatcherTests
     [TestCase("*ac*ae*ag*",          "abacadaeafag",         ExpectedResult = true)]
     [TestCase("*ab*[cd]*e*f*g*",     "abacadaeafag",         ExpectedResult = true)]
     public bool IsMatchSegment(string pattern, string value) =>
-        Matcher.IsMatch(pattern, value, MatchFlags.Unix);
+        Matcher.IsMatch(value, pattern, MatchFlags.Unix);
 
     [TestCase("/dir", "/dir", ExpectedResult = true)]
     [TestCase("dir", "dir",   ExpectedResult = true)]
@@ -399,25 +399,25 @@ public class MatcherTests
     [TestCase("{[sS]rc,test*}/*.cs",  "unittest/app.cs",       ExpectedResult = false)]
     [TestCase("{[sS]rc,test*}/*.cs",  "test/app.cpp",          ExpectedResult = false)]
     public bool IsMatch(string pattern, string path) =>
-        Matcher.IsMatch(pattern, path, MatchFlags.Unix);
+        Matcher.IsMatch(path, pattern, MatchFlags.Unix);
 
     [TestCase(@"\a\b\*\d\e",  "ab*de", ExpectedResult = true)]
     [TestCase(@"\a\b\*\d\e",  "abcde", ExpectedResult = false)]
     public bool IsMatch_Unix(string pattern, string path) =>
-        Matcher.IsMatch(pattern, path, MatchFlags.Unix);
+        Matcher.IsMatch(path, pattern, MatchFlags.Unix);
 
     [TestCase(@"\a\b\*\d\e",  @"\a\b\c\d\e",   ExpectedResult = true)]
     [TestCase(@"\a\b\*\d\e",  @"/a/b\c/d/e",   ExpectedResult = true)]
     [TestCase(@"/a/b/*\d/e",  @"\a\b/c\d\e\",  ExpectedResult = true)]
     [TestCase(@"\a\b\*\d\e",  @"\a\b\c\d\e\f", ExpectedResult = false)]
     public bool IsMatch_Windows(string pattern, string path) =>
-        Matcher.IsMatch(pattern, path, MatchFlags.Windows);
+        Matcher.IsMatch(path, pattern, MatchFlags.Windows);
 
     [Test]
     public void Bang()
     {
-        Matcher.IsMatch("*.txt", new string('a', 10000) + ".txt");
-        Matcher.IsMatch("a*a*a*a*a*a*a*a*a*a*a*a*a*a*b", new string('a', 200));
-        Matcher.IsMatch("a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/b", string.Join("/", Enumerable.Repeat("a", 200)));
+        Matcher.IsMatch(new string('a', 10000) + ".txt", "*.txt");
+        Matcher.IsMatch(new string('a', 200), "a*a*a*a*a*a*a*a*a*a*a*a*a*a*b");
+        Matcher.IsMatch(string.Join("/", Enumerable.Repeat("a", 200)), "a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/a/**/b");
     }
 }

--- a/Ramstack.Globbing/Matcher.cs
+++ b/Ramstack.Globbing/Matcher.cs
@@ -51,19 +51,19 @@ public static unsafe class Matcher
     ///   </item>
     /// </list>
     /// </remarks>
-    /// <param name="pattern">The glob pattern to match against.</param>
     /// <param name="path">The path to test for a match.</param>
+    /// <param name="pattern">The glob pattern to match against.</param>
     /// <param name="flags">The matching options to use. Default is <see cref="MatchFlags.Auto"/>.</param>
     /// <returns>
     /// <c>true</c> if the pattern matches the path; otherwise, <c>false</c>.
     /// </returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsMatch(string pattern, string path, MatchFlags flags = MatchFlags.Auto)
+    public static bool IsMatch(string path, string pattern, MatchFlags flags = MatchFlags.Auto)
     {
-        _ = pattern.Length;
         _ = path.Length;
+        _ = pattern.Length;
 
-        return IsMatch(pattern.AsSpan(), path.AsSpan(), flags);
+        return IsMatch(path.AsSpan(), pattern.AsSpan(), flags);
     }
 
     /// <summary>
@@ -85,20 +85,20 @@ public static unsafe class Matcher
     ///   </item>
     /// </list>
     /// </remarks>
-    /// <param name="pattern">The glob pattern to match against.</param>
     /// <param name="path">The path to test for a match.</param>
+    /// <param name="pattern">The glob pattern to match against.</param>
     /// <param name="flags">The matching options to use. Default is <see cref="MatchFlags.Auto"/>.</param>
     /// <returns>
     /// <c>true</c> if the pattern matches the path; otherwise, <c>false</c>.
     /// </returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsMatch(ReadOnlySpan<char> pattern, ReadOnlySpan<char> path, MatchFlags flags = MatchFlags.Auto)
+    public static bool IsMatch(ReadOnlySpan<char> path, ReadOnlySpan<char> pattern, MatchFlags flags = MatchFlags.Auto)
     {
-        fixed (char* p = &MemoryMarshal.GetReference(pattern))
         fixed (char* v = &MemoryMarshal.GetReference(path))
+        fixed (char* p = &MemoryMarshal.GetReference(pattern))
         {
-            var pend = p + (uint)pattern.Length;
             var vend = v + (uint)path.Length;
+            var pend = p + (uint)pattern.Length;
 
             if (flags == MatchFlags.Windows || flags == MatchFlags.Auto && Path.DirectorySeparatorChar == '\\')
                 return DoMatch<Windows>(p, pend, v, vend) == vend;


### PR DESCRIPTION
Refactored the parameter order in the IsMatch method to prioritize path over pattern, aligning with .NET conventions and improving code readability. This change ensures consistency across method signatures and enhances usability.

**New signature**
```csharp
public static bool IsMatch(string path, string pattern, MatchFlags flags = MatchFlags.Auto)
```
