### PR TITLE
Enhancements to `Files`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Fast and zero-allocation .NET globbing library for matching file paths using [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)).
 No external dependencies.
 
+[![.NET](https://github.com/rameel/ramstack.globbing/actions/workflows/test.yml/badge.svg)](https://github.com/rameel/ramstack.globbing/actions/workflows/test.yml)
+
+
 ## Getting Started
 
 To install the `Ramstack.Globbing` [NuGet package](https://www.nuget.org/packages/Ramstack.Globbing) to your project, run the following command:

--- a/Ramstack.Globbing.Tests/Ramstack.Globbing.Tests.csproj
+++ b/Ramstack.Globbing.Tests/Ramstack.Globbing.Tests.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
     <RootNamespace>Ramstack.Globbing</RootNamespace>
   </PropertyGroup>
 

--- a/Ramstack.Globbing.Tests/Traversal/FilesTests.cs
+++ b/Ramstack.Globbing.Tests/Traversal/FilesTests.cs
@@ -16,23 +16,37 @@ public class FilesTests
     [Test]
     public void EnumerateFiles_Default_IncludesHidden()
     {
-        var count = Files.EnumerateFiles(_storage.Root, "**").Count();
+        var count = Files
+            .EnumerateFiles(_storage.Root, "**")
+            .Count();
+
         Assert.That(count, Is.EqualTo(_storage.FileList.Count));
     }
 
     [Test]
     public void EnumerateDirectories_Default_IncludesHidden()
     {
-        var count = Files.EnumerateDirectories(_storage.Root, "**").Count();
-        var expected = Directory.EnumerateDirectories(_storage.Root, "*", SearchOption.AllDirectories).Count();
+        var count = Files
+            .EnumerateDirectories(_storage.Root, "**")
+            .Count();
+
+        var expected = Directory
+            .EnumerateDirectories(_storage.Root, "*", SearchOption.AllDirectories)
+            .Count();
+
         Assert.That(count, Is.EqualTo(expected));
     }
 
     [Test]
     public void EnumerateFiles_OneLevel()
     {
-        var list = Files.EnumerateFiles(_storage.Root, "project/*").OrderBy(p => p);
-        var expected = Directory.EnumerateFiles(Path.Combine(_storage.Root, "project")).OrderBy(p => p);
+        var list = Files
+            .EnumerateFiles(_storage.Root, "project/*")
+            .OrderBy(p => p);
+
+        var expected = Directory
+            .EnumerateFiles(Path.Combine(_storage.Root, "project"))
+            .OrderBy(p => p);
 
         Assert.That(list, Is.EquivalentTo(expected));
     }
@@ -40,8 +54,13 @@ public class FilesTests
     [Test]
     public void EnumerateDirectories_OneLevel()
     {
-        var list = Files.EnumerateDirectories(_storage.Root, "project/*").OrderBy(p => p);
-        var expected = Directory.EnumerateDirectories(Path.Combine(_storage.Root, "project")).OrderBy(p => p);
+        var list = Files
+            .EnumerateDirectories(_storage.Root, "project/*")
+            .OrderBy(p => p);
+
+        var expected = Directory
+            .EnumerateDirectories(Path.Combine(_storage.Root, "project"))
+            .OrderBy(p => p);
 
         Assert.That(list, Is.EquivalentTo(expected));
     }
@@ -62,8 +81,13 @@ public class FilesTests
     [TestCase("vb")]
     public void EnumerateFiles_ByExtension(string ext)
     {
-        var list = Files.EnumerateFiles(_storage.Root, $"**/*.{ext}").OrderBy(p => p);
-        var expected = Directory.EnumerateFiles(_storage.Root, $"*.{ext}", SearchOption.AllDirectories).OrderBy(p => p);
+        var list = Files
+            .EnumerateFiles(_storage.Root, $"**/*.{ext}")
+            .OrderBy(p => p);
+
+        var expected = Directory
+            .EnumerateFiles(_storage.Root, $"*.{ext}", SearchOption.AllDirectories)
+            .OrderBy(p => p);
 
         Assert.That(list, Is.EquivalentTo(expected));
     }
@@ -71,7 +95,10 @@ public class FilesTests
     [Test]
     public void EnumerateFiles_BraceExtension()
     {
-        var list = Files.EnumerateFiles(_storage.Root, "**/*.{log,dat}").OrderBy(p => p);
+        var list = Files
+            .EnumerateFiles(_storage.Root, "**/*.{log,dat}")
+            .OrderBy(p => p);
+
         var expected = Directory
             .EnumerateFiles(_storage.Root, "*", SearchOption.AllDirectories)
             .Where(p => Path.GetExtension(p) is ".log" or ".dat")
@@ -83,7 +110,10 @@ public class FilesTests
     [Test]
     public void EnumerateFiles_Set()
     {
-        var list = Files.EnumerateFiles(_storage.Root, "**/tests/[a-zA-Z]*/*.xml").OrderBy(p => p);
+        var list = Files
+            .EnumerateFiles(_storage.Root, "**/tests/[a-zA-Z]*/*.xml")
+            .OrderBy(p => p);
+
         var expected = Directory
             .EnumerateFiles(Path.Combine(_storage.Root, "project", "tests"), "*.xml", SearchOption.AllDirectories)
             .OrderBy(p => p);
@@ -94,7 +124,10 @@ public class FilesTests
     [Test]
     public void EnumerateFiles_Logs()
     {
-        var list = Files.EnumerateFiles(_storage.Root, "**/logs/**/*.log").OrderBy(p => p);
+        var list = Files
+            .EnumerateFiles(_storage.Root, "**/logs/**/*.log")
+            .OrderBy(p => p);
+
         var expected = Directory
             .EnumerateFiles(_storage.Root, "*.log", SearchOption.AllDirectories)
             .OrderBy(p => p);
@@ -105,7 +138,10 @@ public class FilesTests
     [Test]
     public void EnumerateFiles_Temps()
     {
-        var list = Files.EnumerateFiles(_storage.Root, "**/{hidden{,-folder}}/**/*.{tmp,dat}").OrderBy(p => p);
+        var list = Files
+            .EnumerateFiles(_storage.Root, "**/{hidden{,-folder}}/**/*.{tmp,dat}")
+            .OrderBy(p => p);
+
         var expected = Directory
             .EnumerateFiles(_storage.Root, "*", SearchOption.AllDirectories)
             .Where(p => Regex.IsMatch(p, @"\b(hidden|hidden-folder)\b"))
@@ -120,7 +156,10 @@ public class FilesTests
     [TestCase(@"project\**\{hidden{,-folder}}\**\*.{tmp,dat}")]
     public void EnumerateFiles_NoEscaping(string pattern)
     {
-        var list = Files.EnumerateFiles(_storage.Root, pattern, flags: MatchFlags.Windows).OrderBy(p => p);
+        var list = Files
+            .EnumerateFiles(_storage.Root, pattern, flags: MatchFlags.Windows)
+            .OrderBy(p => p);
+
         var expected = Directory
             .EnumerateFiles(_storage.Root, "*", SearchOption.AllDirectories)
             .Where(p => Regex.IsMatch(p, @"\b(hidden|hidden-folder)\b"))

--- a/Ramstack.Globbing.Tests/Traversal/FilesTests.cs
+++ b/Ramstack.Globbing.Tests/Traversal/FilesTests.cs
@@ -113,4 +113,17 @@ public class FilesTests
 
         Assert.That(list, Is.EquivalentTo(expected));
     }
+
+    [TestCase(@"**/{hidden{,-folder}}/**/*.{tmp,dat}")]
+    [TestCase(@"**\{hidden{,-folder}}\**\*.{tmp,dat}")]
+    public void EnumerateFiles_NoEscaping(string pattern)
+    {
+        var list = Files.EnumerateFiles(_storage.Root, pattern, flags: MatchFlags.Windows).OrderBy(p => p);
+        var expected = Directory
+            .EnumerateFiles(_storage.Root, "*", SearchOption.AllDirectories)
+            .Where(p => Regex.IsMatch(p, @"\b(hidden|hidden-folder)\b"))
+            .OrderBy(p => p);
+
+        Assert.That(list, Is.EquivalentTo(expected));
+    }
 }

--- a/Ramstack.Globbing.Tests/Traversal/FilesTests.cs
+++ b/Ramstack.Globbing.Tests/Traversal/FilesTests.cs
@@ -1,0 +1,116 @@
+﻿using System.Text.RegularExpressions;
+
+using Ramstack.Globbing.Traversal.Helpers;
+
+namespace Ramstack.Globbing.Traversal;
+
+[TestFixture]
+public class FilesTests
+{
+    private readonly TempFileStorage _storage = new();
+
+    [OneTimeTearDown]
+    public void Cleanup() =>
+        _storage.Dispose();
+
+    [Test]
+    public void EnumerateFiles_Default_IncludesHidden()
+    {
+        var count = Files.EnumerateFiles(_storage.Root, "**").Count();
+        Assert.That(count, Is.EqualTo(_storage.FileList.Count));
+    }
+
+    [Test]
+    public void EnumerateDirectories_Default_IncludesHidden()
+    {
+        var count = Files.EnumerateDirectories(_storage.Root, "**").Count();
+        var expected = Directory.EnumerateDirectories(_storage.Root, "*", SearchOption.AllDirectories).Count();
+        Assert.That(count, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void EnumerateFiles_OneLevel()
+    {
+        var list = Files.EnumerateFiles(_storage.Root, "project/*").OrderBy(p => p);
+        var expected = Directory.EnumerateFiles(Path.Combine(_storage.Root, "project")).OrderBy(p => p);
+
+        Assert.That(list, Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public void EnumerateDirectories_OneLevel()
+    {
+        var list = Files.EnumerateDirectories(_storage.Root, "project/*").OrderBy(p => p);
+        var expected = Directory.EnumerateDirectories(Path.Combine(_storage.Root, "project")).OrderBy(p => p);
+
+        Assert.That(list, Is.EquivalentTo(expected));
+    }
+
+    [TestCase("cs")]
+    [TestCase("csproj")]
+    [TestCase("json")]
+    [TestCase("log")]
+    [TestCase("dat")]
+    [TestCase("tmp")]
+    [TestCase("ps1")]
+    [TestCase("sh")]
+    [TestCase("bat")]
+    [TestCase("md")]
+    [TestCase("sln")]
+    [TestCase("dll")]
+    [TestCase("nupkg")]
+    [TestCase("vb")]
+    public void EnumerateFiles_ByExtension(string ext)
+    {
+        var list = Files.EnumerateFiles(_storage.Root, $"**/*.{ext}").OrderBy(p => p);
+        var expected = Directory.EnumerateFiles(_storage.Root, $"*.{ext}", SearchOption.AllDirectories).OrderBy(p => p);
+
+        Assert.That(list, Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public void EnumerateFiles_BraceExtension()
+    {
+        var list = Files.EnumerateFiles(_storage.Root, "**/*.{log,dat}").OrderBy(p => p);
+        var expected = Directory
+            .EnumerateFiles(_storage.Root, "*", SearchOption.AllDirectories)
+            .Where(p => Path.GetExtension(p) is ".log" or ".dat")
+            .OrderBy(p => p);
+
+        Assert.That(list, Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public void EnumerateFiles_Set()
+    {
+        var list = Files.EnumerateFiles(_storage.Root, "**/tests/[a-zA-Z]*/*.xml").OrderBy(p => p);
+        var expected = Directory
+            .EnumerateFiles(Path.Combine(_storage.Root, "project", "tests"), "*.xml", SearchOption.AllDirectories)
+            .OrderBy(p => p);
+
+        Assert.That(list, Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public void EnumerateFiles_Logs()
+    {
+        var list = Files.EnumerateFiles(_storage.Root, "**/logs/**/*.log").OrderBy(p => p);
+        var expected = Directory
+            .EnumerateFiles(_storage.Root, "*.log", SearchOption.AllDirectories)
+            .OrderBy(p => p);
+
+        Assert.That(list, Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public void EnumerateFiles_Temps()
+    {
+        var list = Files.EnumerateFiles(_storage.Root, "**/{hidden{,-folder}}/**/*.{tmp,dat}").OrderBy(p => p);
+        var expected = Directory
+            .EnumerateFiles(_storage.Root, "*", SearchOption.AllDirectories)
+            .Where(p => Regex.IsMatch(p, @"\b(hidden|hidden-folder)\b"))
+            .OrderBy(p => p);
+
+        Assert.That(list, Is.EquivalentTo(expected));
+    }
+}

--- a/Ramstack.Globbing.Tests/Traversal/FilesTests.cs
+++ b/Ramstack.Globbing.Tests/Traversal/FilesTests.cs
@@ -116,6 +116,8 @@ public class FilesTests
 
     [TestCase(@"**/{hidden{,-folder}}/**/*.{tmp,dat}")]
     [TestCase(@"**\{hidden{,-folder}}\**\*.{tmp,dat}")]
+    [TestCase(@"project/**/{hidden{,-folder}}/**/*.{tmp,dat}")]
+    [TestCase(@"project\**\{hidden{,-folder}}\**\*.{tmp,dat}")]
     public void EnumerateFiles_NoEscaping(string pattern)
     {
         var list = Files.EnumerateFiles(_storage.Root, pattern, flags: MatchFlags.Windows).OrderBy(p => p);
@@ -124,6 +126,25 @@ public class FilesTests
             .Where(p => Regex.IsMatch(p, @"\b(hidden|hidden-folder)\b"))
             .OrderBy(p => p);
 
+        Assert.That(list, Is.EquivalentTo(expected));
+    }
+
+    [TestCase(@"project/**/dataset-\[data]-\{1}.csv")]
+    [TestCase(@"project/**/dataset-\[data\]-\{1\}.csv")]
+    [TestCase(@"project/**/dataset-\[*]-\{[0-9]}.csv")]
+    [TestCase(@"project/**/dataset-*.csv")]
+    public void EnumerateFiles_Escaping(string pattern)
+    {
+        var list = Files
+            .EnumerateFiles(_storage.Root, pattern, flags: MatchFlags.Unix)
+            .OrderBy(p => p)
+            .ToList();
+
+        var expected = Directory
+            .EnumerateFiles(Path.Combine(_storage.Root, "project", "data", "raw"), "dataset-*", SearchOption.AllDirectories)
+            .OrderBy(p => p);
+
+        Assert.That(list.Count, Is.EqualTo(1));
         Assert.That(list, Is.EquivalentTo(expected));
     }
 }

--- a/Ramstack.Globbing.Tests/Traversal/Helpers/TempFileStorage.cs
+++ b/Ramstack.Globbing.Tests/Traversal/Helpers/TempFileStorage.cs
@@ -39,7 +39,7 @@ public class TempFileStorage : IDisposable
 
             "project/data/raw/dataset1.csv",
             "project/data/raw/dataset2.csv",
-            "project/data/raw/large_file.parquet",
+            "project/data/raw/dataset-[data]-{1}.csv",
             "project/data/processed/cleaned_data.csv",
             "project/data/processed/aggregated_results.json",
 

--- a/Ramstack.Globbing.Tests/Traversal/Helpers/TempFileStorage.cs
+++ b/Ramstack.Globbing.Tests/Traversal/Helpers/TempFileStorage.cs
@@ -1,0 +1,114 @@
+﻿namespace Ramstack.Globbing.Traversal.Helpers;
+
+public class TempFileStorage : IDisposable
+{
+    public string Root { get; }
+    public IReadOnlyList<string> FileList { get; }
+
+    public TempFileStorage()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var list = new[]
+        {
+            "project/docs/user_manual.pdf",
+            "project/docs/api_reference.md",
+            "project/docs/troubleshooting/common_issues.txt",
+            "project/docs/troubleshooting/faq.docx",
+
+            "project/docs_generated/html/index.html",
+            "project/docs_generated/html/api.html",
+            "project/docs_generated/pdf/documentation.pdf",
+
+            "project/src/App/App.csproj",
+            "project/src/App/Program.cs",
+            "project/src/App/Utils.cs",
+            "project/src/Modules/Module1/Module1.cs",
+            "project/src/Modules/Module1/Module1.csproj",
+            "project/src/Modules/Module1/Submodule/Submodule1.cs",
+            "project/src/Modules/Module1/Submodule/Submodule2.cs",
+            "project/src/Modules/Module1/Submodule/Submodule.csproj",
+            "project/src/Modules/Module2/Module2.cs",
+            "project/src/Modules/Module2/Module2.csproj",
+            "project/src/App.sln",
+
+            "project/tests/TestMain.cs",
+            "project/tests/TestUtils.cs",
+            "project/tests/Tests.csproj",
+            "project/tests/Fixtures/SampleData.json",
+            "project/tests/Fixtures/MockResponses.xml",
+
+            "project/data/raw/dataset1.csv",
+            "project/data/raw/dataset2.csv",
+            "project/data/raw/large_file.parquet",
+            "project/data/processed/cleaned_data.csv",
+            "project/data/processed/aggregated_results.json",
+
+            "project/data/temp/temp_file1.tmp",
+            "project/data/temp/temp_file2.tmp",
+            "project/data/temp/ac/b2/34/2d/7e/temp_file2.tmp",
+            "project/data/temp/hidden-folder/temp_1.tmp",
+            "project/data/temp/hidden-folder/temp_2.tmp",
+            "project/data/temp/hidden/temp_hidden3.dat",
+            "project/data/temp/hidden/temp_hidden4.dat",
+
+            "project/scripts/setup.p1",
+            "project/scripts/deploy.ps1",
+            "project/scripts/build.bat",
+            "project/scripts/build.sh",
+
+            "project/logs/app.log",
+            "project/logs/error.log",
+            "project/logs/archive/2019/01/app_2019-01.log",
+            "project/logs/archive/2019/02/app_2019-02.log",
+            "project/logs/archive/2019/03/app_2019-03.log",
+
+            "project/config/production.json",
+            "project/config/development.json",
+            "project/config/test.json",
+
+            "project/assets/images/logo.png",
+            "project/assets/images/icon.svg",
+            "project/assets/images/backgrounds/light.jpg",
+            "project/assets/images/backgrounds/dark.jpg",
+
+            "project/assets/fonts/opensans.ttf",
+            "project/assets/fonts/roboto.ttf",
+            "project/assets/styles/main.css",
+            "project/assets/styles/print.css",
+
+            "project/packages/Ramstack.Globbing.2.1.0/lib/net60/Ramstack.Globbing.dll",
+            "project/packages/Ramstack.Globbing.2.1.0/Ramstack.Globbing.2.1.0.nupkg",
+
+            "project/.gitignore",
+            "project/.editorconfig",
+            "project/README.md",
+            "project/global.json",
+            "project/nuget.config",
+        }
+            .Select(p => Path.Combine(root, p))
+            .ToArray();
+
+        var directories = list
+            .Select(p => Path.GetDirectoryName(p)!)
+            .Distinct()
+            .ToArray();
+
+        foreach (var path in directories)
+            Directory.CreateDirectory(path);
+
+        foreach (var path in list)
+            File.WriteAllText(path, $"Automatically generated for testing on {DateTime.Now:s}");
+
+        var hiddenFolder = directories.First(p => p.Contains("hidden-folder"));
+        File.SetAttributes(hiddenFolder, FileAttributes.Hidden);
+
+        foreach (var hiddenFile in list.Where(p => p.Contains("temp_hidden")))
+            File.SetAttributes(hiddenFile, FileAttributes.Hidden);
+
+        Root = root;
+        FileList = list;
+    }
+
+    public void Dispose() =>
+        Directory.Delete(Root, true);
+}

--- a/Ramstack.Globbing.Tests/Utilities/PathHelperTests.cs
+++ b/Ramstack.Globbing.Tests/Utilities/PathHelperTests.cs
@@ -1,0 +1,71 @@
+namespace Ramstack.Globbing.Utilities;
+
+[TestFixture]
+public class PathHelperTests
+{
+    [Test]
+    public void ToForwardSlashed_NothingChange()
+    {
+        for (var n = 0; n < 512; n++)
+        {
+            var original = new string('@', n + 16).ToCharArray().AsSpan();
+            var span = original[8..^8];
+            span.Fill('a');
+
+            var expected = original.ToString();
+            PathHelper.ToForwardSlashed(span);
+
+            Assert.That(original.ToString(), Is.EqualTo(expected));
+        }
+    }
+
+    [Test]
+    public void ToForwardSlashed_ChangesAll()
+    {
+        for (var n = 0; n < 512; n++)
+        {
+            var original = new string('@', n + 16).ToCharArray().AsSpan();
+            var span = original[8..^8];
+            span.Fill('\\');
+
+            var expected = original.ToString().Replace('\\', '/');
+            PathHelper.ToForwardSlashed(span);
+
+            Assert.That(original.ToString(), Is.EqualTo(expected));
+        }
+    }
+
+    [Test]
+    public void ToForwardSlashed_ForwardSlahes()
+    {
+        for (var n = 0; n < 512; n++)
+        {
+            var original = new string('@', n + 16).ToCharArray().AsSpan();
+            var span = original[8..^8];
+            span.Fill('/');
+
+            var expected = original.ToString().Replace('\\', '/');
+            PathHelper.ToForwardSlashed(span);
+
+            Assert.That(original.ToString(), Is.EqualTo(expected));
+        }
+    }
+
+    [Test]
+    public void ToForwardSlashed_RareChanges()
+    {
+        for (var n = 0; n < 512; n++)
+        {
+            var original = new string('@', n + 16).ToCharArray().AsSpan();
+            var span = original[8..^8];
+            for (var i = 0; i < span.Length; i++)
+                if (i % 7 == 0)
+                    span[i] = '\\';
+
+            var expected = original.ToString().Replace('\\', '/');
+            PathHelper.ToForwardSlashed(span);
+
+            Assert.That(original.ToString(), Is.EqualTo(expected));
+        }
+    }
+}

--- a/Ramstack.Globbing.Tests/Utilities/PathHelperTests.cs
+++ b/Ramstack.Globbing.Tests/Utilities/PathHelperTests.cs
@@ -4,7 +4,7 @@ namespace Ramstack.Globbing.Utilities;
 public class PathHelperTests
 {
     [Test]
-    public void ToForwardSlashed_NothingChange()
+    public void ConvertToForwardSlashes_NothingChange()
     {
         for (var n = 0; n < 512; n++)
         {
@@ -13,14 +13,14 @@ public class PathHelperTests
             span.Fill('a');
 
             var expected = original.ToString();
-            PathHelper.ToForwardSlashed(span);
+            PathHelper.ConvertToForwardSlashes(span);
 
             Assert.That(original.ToString(), Is.EqualTo(expected));
         }
     }
 
     [Test]
-    public void ToForwardSlashed_ChangesAll()
+    public void ConvertToForwardSlashes_ChangesAll()
     {
         for (var n = 0; n < 512; n++)
         {
@@ -29,14 +29,14 @@ public class PathHelperTests
             span.Fill('\\');
 
             var expected = original.ToString().Replace('\\', '/');
-            PathHelper.ToForwardSlashed(span);
+            PathHelper.ConvertToForwardSlashes(span);
 
             Assert.That(original.ToString(), Is.EqualTo(expected));
         }
     }
 
     [Test]
-    public void ToForwardSlashed_ForwardSlahes()
+    public void ConvertToForwardSlashes_ForwardSlahes()
     {
         for (var n = 0; n < 512; n++)
         {
@@ -45,14 +45,14 @@ public class PathHelperTests
             span.Fill('/');
 
             var expected = original.ToString().Replace('\\', '/');
-            PathHelper.ToForwardSlashed(span);
+            PathHelper.ConvertToForwardSlashes(span);
 
             Assert.That(original.ToString(), Is.EqualTo(expected));
         }
     }
 
     [Test]
-    public void ToForwardSlashed_RareChanges()
+    public void ConvertToForwardSlashes_RareChanges()
     {
         for (var n = 0; n < 512; n++)
         {
@@ -63,7 +63,7 @@ public class PathHelperTests
                     span[i] = '\\';
 
             var expected = original.ToString().Replace('\\', '/');
-            PathHelper.ToForwardSlashed(span);
+            PathHelper.ConvertToForwardSlashes(span);
 
             Assert.That(original.ToString(), Is.EqualTo(expected));
         }

--- a/Ramstack.Globbing/Internal/PathHelper.cs
+++ b/Ramstack.Globbing/Internal/PathHelper.cs
@@ -1,0 +1,91 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace Ramstack.Globbing.Internal;
+
+internal static class PathHelper
+{
+    public static void ToForwardSlashed(Span<char> value)
+    {
+        var length = (nint)(uint)value.Length;
+        ref var reference = ref Unsafe.As<char, ushort>(
+            ref MemoryMarshal.GetReference(value));
+
+        ReplaceImpl(ref reference, length);
+    }
+
+    [SuppressMessage("ReSharper", "RedundantCast")]
+    private static void ReplaceImpl(ref ushort p, nint length)
+    {
+        var i = (nint)0;
+
+        if (Sse41.IsSupported && length >= Vector128<ushort>.Count)
+        {
+            var slash = Vector128.Create((ushort)'/');
+            var backslash = Vector128.Create((ushort)'\\');
+            var tail = length - Vector128<ushort>.Count;
+
+            Vector128<ushort> value;
+            Vector128<ushort> mask;
+            Vector128<ushort> result;
+
+            while (i < tail)
+            {
+                value = LoadVector(ref p, i);
+                mask = Sse2.CompareEqual(value, backslash);
+                result = Sse41.BlendVariable(value, slash, mask);
+                WriteVector(ref p, i, result);
+
+                i += Vector128<ushort>.Count;
+            }
+
+            value = LoadVector(ref p, tail);
+            mask = Sse2.CompareEqual(value, backslash);
+            result = Sse41.BlendVariable(value, slash, mask);
+            WriteVector(ref p, tail, result);
+        }
+        //else if (AdvSimd.IsSupported && length >= Vector128<ushort>.Count)
+        //{
+        //    var slash = Vector128.Create((ushort)'/');
+        //    var backslash = Vector128.Create((ushort)'\\');
+        //    var tail = length - Vector128<ushort>.Count;
+
+        //    Vector128<ushort> value;
+        //    Vector128<ushort> mask;
+        //    Vector128<ushort> result;
+
+        //    while (i < tail)
+        //    {
+        //        value = LoadVector(ref p, i);
+        //        mask = AdvSimd.CompareEqual(value, backslash);
+        //        result = AdvSimd.BitwiseSelect(mask, slash, value);
+        //        WriteVector(ref p, i, result);
+
+        //        i += Vector128<ushort>.Count;
+        //    }
+
+        //    value = LoadVector(ref p, tail);
+        //    mask = AdvSimd.CompareEqual(value, backslash);
+        //    result = AdvSimd.BitwiseSelect(mask, slash, value);
+        //    WriteVector(ref p, tail, result);
+        //}
+        else
+        {
+            for (; i < length; i++)
+                if (Unsafe.Add(ref p, i) == '\\')
+                    Unsafe.Add(ref p, i) = '/';
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector128<ushort> LoadVector(ref ushort p, nint offset) =>
+        Unsafe.ReadUnaligned<Vector128<ushort>>(
+            ref Unsafe.As<ushort, byte>(ref Unsafe.Add(ref p, offset)));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteVector(ref ushort p, nint offset, Vector128<ushort> value) =>
+        Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref Unsafe.Add(ref p, offset)), value);
+}

--- a/Ramstack.Globbing/MatchFlags.cs
+++ b/Ramstack.Globbing/MatchFlags.cs
@@ -16,11 +16,11 @@ public enum MatchFlags
     /// This flag provides behavior consistent with Windows-style paths.
     /// Both backslashes (<c>\</c>) and forward (<c>/</c>) slashes are considered as path separators in this mode.
     /// </summary>
-    Windows,
+    Windows = 2 | 0x800,
 
     /// <summary>
     /// Treats backslashes <c>\</c> as escape sequences, allowing for special character escaping.
     /// This flag provides behavior consistent with Unix-style paths.
     /// </summary>
-    Unix
+    Unix = 4 | 0x800
 }

--- a/Ramstack.Globbing/Ramstack.Globbing.csproj
+++ b/Ramstack.Globbing/Ramstack.Globbing.csproj
@@ -34,6 +34,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Ramstack.Globbing.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Ramstack.Globbing/Traversal/Files.cs
+++ b/Ramstack.Globbing/Traversal/Files.cs
@@ -178,7 +178,7 @@ public static partial class Files
         // Otherwise, the backslash (\) in the path will be treated as an escape character,
         // and as a result, the `Unix` flag will essentially not work on a Windows system.
         if (Path.DirectorySeparatorChar == '\\' && flags == MatchFlags.Unix)
-            PathHelper.ToForwardSlashed(path);
+            PathHelper.ConvertToForwardSlashes(path);
     }
 
     private static MatchFlags AdjustMatchFlags(MatchFlags flags)

--- a/Ramstack.Globbing/Traversal/Files.cs
+++ b/Ramstack.Globbing/Traversal/Files.cs
@@ -4,7 +4,7 @@ using System.IO.Enumeration;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-using Ramstack.Globbing.Internal;
+using Ramstack.Globbing.Utilities;
 
 namespace Ramstack.Globbing.Traversal;
 

--- a/Ramstack.Globbing/Traversal/Files.cs
+++ b/Ramstack.Globbing/Traversal/Files.cs
@@ -51,7 +51,8 @@ public static partial class Files
 
     private static bool IsPartialMatch(ReadOnlySpan<char> path, string[] patterns, MatchFlags flags)
     {
-        var depth = CountPathSegments(path, flags) - 1;
+        var depth = CountPathSegments(path, flags);
+
         foreach (var pattern in patterns)
             if (Matcher.IsMatch(path, GetPartialPattern(pattern, depth), flags))
                 return true;
@@ -94,7 +95,7 @@ public static partial class Files
         while (Unsafe.IsAddressLessThan(ref s, ref e) && s == '/')
             s = ref Unsafe.Add(ref s, 1);
 
-        var separator = false;
+        var separator = true;
         var i = (nint)0;
 
         for (; i < pattern.Length; i++)

--- a/Ramstack.Globbing/Traversal/TraveralOptions.cs
+++ b/Ramstack.Globbing/Traversal/TraveralOptions.cs
@@ -8,13 +8,13 @@ public sealed class TraversalOptions
     /// <summary>
     /// Gets or sets the match flags. The default is <see cref="MatchFlags.Auto"/>
     /// </summary>
-    public MatchFlags MatchFlags { get; set; }
+    public MatchFlags MatchFlags { get; set; } = MatchFlags.Auto;
 
     /// <summary>
     /// Gets or sets the attributes to skip.
-    /// The default is <c>FileAttributes.Hidden | FileAttributes.System</c>.
+    /// The default is <c>0 (None)</c>.
     /// </summary>
-    public FileAttributes AttributesToSkip { get; set; } = FileAttributes.Hidden | FileAttributes.System;
+    public FileAttributes AttributesToSkip { get; set; } = DefaultAttributesToSkip;
 
     /// <summary>
     /// Gets or sets a value that indicates the maximum directory depth to recurse while traversing.
@@ -23,7 +23,7 @@ public sealed class TraversalOptions
     /// <remarks>
     /// If <see cref="MaxRecursionDepth"/> is set to zero, the contents of the initial directory will be returned.
     /// </remarks>
-    public int MaxRecursionDepth { get; set; } = int.MaxValue;
+    public int MaxRecursionDepth { get; set; } = DefaultMaxRecursionDepth;
 
     /// <summary>
     /// Gets or sets a value that indicates whether to skip files or directories when access is denied
@@ -42,6 +42,18 @@ public sealed class TraversalOptions
     /// </summary>
     internal static readonly EnumerationOptions DefaultEnumerationOptions = new()
     {
+        IgnoreInaccessible = true,
+        AttributesToSkip = DefaultAttributesToSkip,
         RecurseSubdirectories = true
     };
+
+    /// <summary>
+    /// The default file attributes to skip while traversing.
+    /// </summary>
+    internal const FileAttributes DefaultAttributesToSkip = 0;
+
+    /// <summary>
+    /// The default value for the maximum directory depth to recurse while traversing.
+    /// </summary>
+    internal const int DefaultMaxRecursionDepth = int.MaxValue;
 }

--- a/Ramstack.Globbing/Traversal/TraversalOptionsExtensions.cs
+++ b/Ramstack.Globbing/Traversal/TraversalOptionsExtensions.cs
@@ -14,7 +14,10 @@ internal static class TraversalOptionsExtensions
     /// </returns>
     public static EnumerationOptions ToEnumerationOptions(this TraversalOptions? options)
     {
-        if (options is null or { IgnoreInaccessible: true, AttributesToSkip: (FileAttributes.Hidden | FileAttributes.System), MaxRecursionDepth: int.MaxValue })
+        if (options is null or {
+            AttributesToSkip: TraversalOptions.DefaultAttributesToSkip,
+            MaxRecursionDepth: TraversalOptions.DefaultMaxRecursionDepth,
+            IgnoreInaccessible: true })
             return TraversalOptions.DefaultEnumerationOptions;
 
         return new EnumerationOptions

--- a/Ramstack.Globbing/Utilities/PathHelper.cs
+++ b/Ramstack.Globbing/Utilities/PathHelper.cs
@@ -7,9 +7,16 @@ using System.Runtime.Intrinsics.X86;
 
 namespace Ramstack.Globbing.Utilities;
 
+/// <summary>
+/// Provides helper methods for path manipulations.
+/// </summary>
 internal static class PathHelper
 {
-    public static void ToForwardSlashed(Span<char> value)
+    /// <summary>
+    /// Converts all backslashes in the specified span of characters to forward slashes.
+    /// </summary>
+    /// <param name="value">The span of characters to modify.</param>
+    public static void ConvertToForwardSlashes(scoped Span<char> value)
     {
         var length = (nint)(uint)value.Length;
         ref var reference = ref Unsafe.As<char, ushort>(

--- a/Ramstack.Globbing/Utilities/PathHelper.cs
+++ b/Ramstack.Globbing/Utilities/PathHelper.cs
@@ -5,7 +5,7 @@ using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
-namespace Ramstack.Globbing.Internal;
+namespace Ramstack.Globbing.Utilities;
 
 internal static class PathHelper
 {


### PR DESCRIPTION
- Account for MatchFlags in path matching operations
- Fix bug where leading ** was skipped in path patterns
- Enable escaping in Windows systems